### PR TITLE
WIP for improving plugins handling.

### DIFF
--- a/cmd/charm/charmcmd/export_test.go
+++ b/cmd/charm/charmcmd/export_test.go
@@ -51,6 +51,6 @@ func (c *listResourcesCommand) Channel() string {
 	return c.channel
 }
 
-func ResetGetPluginDescriptionsResults() {
-	getPluginDescriptionsResults = nil
+func ResetPluginDescriptionsResults() {
+	pluginDescriptionsResults = nil
 }

--- a/cmd/charm/charmcmd/plugin.go
+++ b/cmd/charm/charmcmd/plugin.go
@@ -44,22 +44,18 @@ type pluginCommand struct {
 	doc     string
 }
 
-// Info returns informationa bout the Command.
+// Info returns information about the Command.
 func (pc *pluginCommand) Info() *cmd.Info {
 	purpose := pc.purpose
 	if purpose == "" {
 		purpose = "support charm plugins"
-	}
-	name := pc.name
-	if name == "" {
-		name = pc.name
 	}
 	doc := pc.doc
 	if doc == "" {
 		doc = pluginTopicText
 	}
 	return &cmd.Info{
-		Name:    name,
+		Name:    pc.name,
 		Purpose: purpose,
 		Doc:     doc,
 	}
@@ -112,15 +108,15 @@ func pluginHelpTopic() string {
 	return output.String()
 }
 
-// getPluginDescriptionsResults holds memoized results for getPluginDescriptions.
-var getPluginDescriptionsResults []pluginDescription
+// pluginDescriptionsResults holds memoized results for getPluginDescriptions.
+var pluginDescriptionsResults []pluginDescription
 
 // getPluginDescriptions runs each plugin with "--description".  The calls to
 // the plugins are run in parallel, so the function should only take as long
 // as the longest call.
 func getPluginDescriptions() []pluginDescription {
-	if len(getPluginDescriptionsResults) > 0 {
-		return getPluginDescriptionsResults
+	if len(pluginDescriptionsResults) > 0 {
+		return pluginDescriptionsResults
 	}
 	plugins := findPlugins()
 	results := []pluginDescription{}
@@ -185,7 +181,7 @@ func getPluginDescriptions() []pluginDescription {
 		result.doc = resultHelpMap[plugin].doc
 		results = append(results, result)
 	}
-	getPluginDescriptionsResults = results
+	pluginDescriptionsResults = results
 	return results
 }
 

--- a/cmd/charm/charmcmd/plugin_test.go
+++ b/cmd/charm/charmcmd/plugin_test.go
@@ -37,7 +37,7 @@ func (s *pluginSuite) SetUpTest(c *gc.C) {
 	s.dir = c.MkDir()
 	s.dir2 = c.MkDir()
 	s.PatchEnvironment("PATH", s.dir+":"+s.dir2)
-	charmcmd.ResetGetPluginDescriptionsResults()
+	charmcmd.ResetPluginDescriptionsResults()
 }
 
 func (*pluginSuite) TestPluginHelpNoPlugins(c *gc.C) {

--- a/cmd/charm/charmcmd/supercmd.go
+++ b/cmd/charm/charmcmd/supercmd.go
@@ -1,0 +1,83 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the GPLv3, see LICENCE file for details.
+
+package charmcmd
+
+import (
+	"github.com/juju/cmd"
+)
+
+// commandWithPlugins is a cmd.Command with the ability to check if some
+// provided args refer to a registered plugin, and in that case, to properly
+// initialize the plugin.
+type commandWithPlugins interface {
+	cmd.Command
+	isPlugin(args []string) bool
+	initPlugin(name string, args []string)
+}
+
+// newSuperCommand creates and returns a new superCommand wrapping the given
+// cmd.SuperCommand.
+func newSuperCommand(supercmd *cmd.SuperCommand) *superCommand {
+	return &superCommand{
+		SuperCommand: supercmd,
+		all: map[string]bool{
+			// The help command is registered by the super command.
+			"help": true,
+		},
+	}
+}
+
+// superCommand is a cmd.SuperCommand that can keep track of registered
+// subcommands and plugins. superCommand implements commandWithPlugins.
+type superCommand struct {
+	*cmd.SuperCommand
+	plugins map[string]cmd.Command
+	all     map[string]bool
+}
+
+// register registers the given command so that it is made available to be used
+// from the super command.
+func (s *superCommand) register(command cmd.Command) {
+	s.SuperCommand.Register(command)
+	s.all[command.Info().Name] = true
+}
+
+// registerPlugins registers all found plugins as subcommands.
+func (s *superCommand) registerPlugins() {
+	plugins := getPluginDescriptions()
+	s.plugins = make(map[string]cmd.Command, len(plugins))
+	for _, plugin := range plugins {
+		if s.isAvailable(plugin.name) {
+			command := &pluginCommand{
+				name:    plugin.name,
+				purpose: plugin.description,
+				doc:     plugin.doc,
+			}
+			s.register(command)
+			s.plugins[plugin.name] = command
+		}
+	}
+	s.SuperCommand.AddHelpTopicCallback(
+		"plugins", "Show "+s.SuperCommand.Name+" plugins", pluginHelpTopic)
+}
+
+// isAvailable reports whether the given command name is available, meaning
+// it has not been already registered.
+func (s *superCommand) isAvailable(name string) bool {
+	return !s.all[name]
+}
+
+// isPlugin reports whether the given super command arguments call a plugin.
+func (s *superCommand) isPlugin(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	_, ok := s.plugins[args[0]]
+	return ok
+}
+
+// initPlugin initialize a registered plugin using the given args.
+func (s *superCommand) initPlugin(name string, args []string) {
+	s.plugins[name].Init(args)
+}


### PR DESCRIPTION
Do not register plugins that have the same name as an internal command.

This will need increasing test coverage: exercise registering commands, plugins, trying to register a plugin with the same name as a previous internal command or plugin.
