### PR TITLE
cmd/charm/charmcmd: rework VCS log parsing

### DIFF
--- a/cmd/charm/charmcmd/export_test.go
+++ b/cmd/charm/charmcmd/export_test.go
@@ -4,18 +4,15 @@
 package charmcmd
 
 var (
-	ClientGetArchive            = &clientGetArchive
-	CSClientServerURL           = &csclientServerURL
-	GetExtraInfo                = getExtraInfo
-	MapLogEntriesToVcsRevisions = mapLogEntriesToVcsRevisions
-	ParseGitLog                 = parseGitLog
-	PluginTopicText             = pluginTopicText
-	ServerURL                   = serverURL
-	UploadResource              = &uploadResource
-	PublishCharm                = &publishCharm
-	ListResources               = &listResources
-	TranslateError              = translateError
-	USSOTokenPath               = ussoTokenPath
+	ClientGetArchive  = &clientGetArchive
+	CSClientServerURL = &csclientServerURL
+	PluginTopicText   = pluginTopicText
+	ServerURL         = serverURL
+	UploadResource    = &uploadResource
+	PublishCharm      = &publishCharm
+	ListResources     = &listResources
+	TranslateError    = translateError
+	USSOTokenPath     = ussoTokenPath
 )
 
 func ResetPluginDescriptionsResults() {

--- a/cmd/charm/charmcmd/plugin_test.go
+++ b/cmd/charm/charmcmd/plugin_test.go
@@ -233,7 +233,6 @@ func writePlugin(dir, name, content string, perm os.FileMode) {
 	if err := ioutil.WriteFile(path, []byte(content), perm); err != nil {
 		panic(err)
 	}
-	fmt.Println("wrote ", path)
 }
 
 type pluginParams struct {

--- a/cmd/charm/charmcmd/publish_test.go
+++ b/cmd/charm/charmcmd/publish_test.go
@@ -261,7 +261,7 @@ func (s *publishSuite) entityRevision(id *charm.URL, channel params.Channel) int
 	panic(err)
 }
 
-func (s publishSuite) TestRunResource(c *gc.C) {
+func (s *publishSuite) TestRunResource(c *gc.C) {
 	var (
 		actualID        *charm.URL
 		actualResources map[string]int

--- a/cmd/charm/charmcmd/push_internal_test.go
+++ b/cmd/charm/charmcmd/push_internal_test.go
@@ -1,0 +1,496 @@
+package charmcmd
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type pushInternalSuite struct {
+}
+
+var _ = gc.Suite(&pushInternalSuite{})
+
+var parseLogOutputTests = []struct {
+	about           string
+	vcsName         string
+	output          string
+	expectRevisions []vcsRevision
+	expectError     string
+}{{
+	about:   "hg output",
+	vcsName: "hg",
+	output: `0e68f6fcfa75Jay R. Wrenjrwren@xmtp.net2015-09-01 10:39:01 -0500now I have a user name62755f248a17jrwrenjrwren@xmtp.net2015-09-01 10:31:01 -0500' " and a quote and 🍺  and a smile
+
+right ?5b6c84261061jrwrenjrwren@xmtp.net2015-09-01 10:29:01 -0500ladidadi`,
+	expectRevisions: []vcsRevision{{
+		Authors: []vcsAuthor{{
+			Name:  "Jay R. Wren",
+			Email: "jrwren@xmtp.net",
+		}},
+		Commit:  "0e68f6fcfa75",
+		Message: "now I have a user name",
+		Date:    mustParseTime("2015-09-01T10:39:01-05:00"),
+	}, {
+		Authors: []vcsAuthor{{
+			Name:  "jrwren",
+			Email: "jrwren@xmtp.net",
+		}},
+		Commit: "62755f248a17",
+		Message: `' " and a quote and 🍺  and a smile
+
+right ?`,
+		Date: mustParseTime("2015-09-01T10:31:01-05:00"),
+	}, {
+		Authors: []vcsAuthor{{
+			Name:  "jrwren",
+			Email: "jrwren@xmtp.net",
+		}},
+		Commit:  "5b6c84261061",
+		Message: "ladidadi",
+		Date:    mustParseTime("2015-09-01T10:29:01-05:00"),
+	}},
+}, {
+	about:   "git output",
+	vcsName: "git",
+	output: ` 6827b561164edbadf9e063e86aa5bddf9ff5d82eJay R. Wrenjrwren@xmtp.net2015-08-31 14:24:26 -0500this is a commit
+
+hello!
+
+050371d9213fee776b85e4ce40bf13e1a9fec4f8Jay R. Wrenjrwren@xmtp.net2015-08-31 13:54:59 -0500silly"
+complex
+log
+message
+'
+😁
+
+02f607004604568640ea0a126f0022789070cfc3Jay R. Wrenjrwren@xmtp.net2015-08-31 12:05:32 -0500try 2
+
+11cc03952eb993b6b7879f6e62049167678ff14dJay R. Wrenjrwren@xmtp.net2015-08-31 12:03:39 -0500hello fabrice
+
+`,
+	expectRevisions: []vcsRevision{{
+		Authors: []vcsAuthor{{
+			Name:  "Jay R. Wren",
+			Email: "jrwren@xmtp.net",
+		}},
+		Date:   mustParseTime("2015-08-31T14:24:26-05:00"),
+		Commit: "6827b561164edbadf9e063e86aa5bddf9ff5d82e",
+		Message: `this is a commit
+
+hello!`,
+	}, {
+		Authors: []vcsAuthor{{
+			Name:  "Jay R. Wren",
+			Email: "jrwren@xmtp.net",
+		}},
+		Date:   mustParseTime("2015-08-31T13:54:59-05:00"),
+		Commit: "050371d9213fee776b85e4ce40bf13e1a9fec4f8",
+		Message: `silly"
+complex
+log
+message
+'
+😁`,
+	}, {
+		Authors: []vcsAuthor{{
+			Name:  "Jay R. Wren",
+			Email: "jrwren@xmtp.net",
+		}},
+		Date:    mustParseTime("2015-08-31T12:05:32-05:00"),
+		Commit:  "02f607004604568640ea0a126f0022789070cfc3",
+		Message: `try 2`,
+	}, {
+		Authors: []vcsAuthor{{
+			Name:  "Jay R. Wren",
+			Email: "jrwren@xmtp.net",
+		}},
+		Date:    mustParseTime("2015-08-31T12:03:39-05:00"),
+		Commit:  "11cc03952eb993b6b7879f6e62049167678ff14d",
+		Message: "hello fabrice",
+	}},
+}, {
+	about:   "bzr output",
+	vcsName: "bzr",
+	output: `------------------------------------------------------------
+revno: 57
+revision-id: roger.peppe@canonical.com-20160414165404-imszq8k3gr0ntfql
+parent: roger.peppe@canonical.com-20160414164658-u8pg4k6r8ezd7b8d
+author: Mary Smith <mary@x.test>, jdoe@example.org, Who? <one@y.test>
+committer: Roger Peppe <roger.peppe@canonical.com>
+branch nick: wordpress
+timestamp: Thu 2016-04-14 17:54:04 +0100
+message:
+  multiple authors
+------------------------------------------------------------
+revno: 56
+revision-id: roger.peppe@canonical.com-20160414164658-u8pg4k6r8ezd7b8d
+parent: roger.peppe@canonical.com-20160414164354-xq2xleb0e9hvyzem
+author: A. N. Other <another@nowhere.com>
+committer: Roger Peppe <roger.peppe@canonical.com>
+branch nick: wordpress
+timestamp: Thu 2016-04-14 17:46:58 +0100
+message:
+  hello
+------------------------------------------------------------
+revno: 55
+revision-id: roger.peppe@canonical.com-20160414164354-xq2xleb0e9hvyzem
+parent: clint@ubuntu.com-20120618202816-c0iuyzr7nrwowwpv
+committer: Roger Peppe <roger.peppe@canonical.com>
+branch nick: wordpress
+timestamp: Thu 2016-04-14 17:43:54 +0100
+message:
+  A commit message
+  with some extra lines
+  	And some indentation.
+  And quotes '$.
+------------------------------------------------------------
+revno: 54
+revision-id: clint@ubuntu.com-20120618202816-c0iuyzr7nrwowwpv
+parent: clint@fewbar.com-20120618145422-ebta2xe3djn55ovf
+committer: Clint Byrum <clint@ubuntu.com>
+branch nick: wordpress
+timestamp: Mon 2012-06-18 13:28:16 -0700
+message:
+  Fixing so wordpress is configured as the only thing on port 80
+------------------------------------------------------------
+revno: 53
+revision-id: clint@fewbar.com-20120618145422-ebta2xe3djn55ovf
+parent: clint@ubuntu.com-20120522223500-lcjebki0k1oynz02
+committer: Clint Byrum <clint@fewbar.com>
+branch nick: wordpress
+timestamp: Mon 2012-06-18 07:54:22 -0700
+message:
+  fixing website relation for providers who set invalid hostnames (local)
+`,
+	expectRevisions: []vcsRevision{{
+		Authors: []vcsAuthor{{
+			Name:  "Mary Smith",
+			Email: "mary@x.test",
+		}, {
+			Email: "jdoe@example.org",
+		}, {
+			Name:  "Who?",
+			Email: "one@y.test",
+		}},
+		Date:    mustParseTime("2016-04-14T17:54:04+01:00"),
+		Commit:  "roger.peppe@canonical.com-20160414165404-imszq8k3gr0ntfql",
+		Revno:   57,
+		Message: "  multiple authors\n",
+	}, {
+		Authors: []vcsAuthor{{
+			Name:  "A. N. Other",
+			Email: "another@nowhere.com",
+		}},
+		Date:    mustParseTime("2016-04-14T17:46:58+01:00"),
+		Commit:  "roger.peppe@canonical.com-20160414164658-u8pg4k6r8ezd7b8d",
+		Revno:   56,
+		Message: "  hello\n",
+	}, {
+		Authors: []vcsAuthor{{
+			Name:  "Roger Peppe",
+			Email: "roger.peppe@canonical.com",
+		}},
+		Date:   mustParseTime("2016-04-14T17:43:54+01:00"),
+		Commit: "roger.peppe@canonical.com-20160414164354-xq2xleb0e9hvyzem",
+		Revno:  55,
+		Message: `  A commit message
+  with some extra lines
+  	And some indentation.
+  And quotes '$.
+`,
+	}, {
+		Authors: []vcsAuthor{{
+			Name:  "Clint Byrum",
+			Email: "clint@ubuntu.com",
+		}},
+		Date:   mustParseTime("2012-06-18T13:28:16-07:00"),
+		Commit: "clint@ubuntu.com-20120618202816-c0iuyzr7nrwowwpv",
+		Revno:  54,
+		Message: `  Fixing so wordpress is configured as the only thing on port 80
+`,
+	}, {
+		Authors: []vcsAuthor{{
+			Name:  "Clint Byrum",
+			Email: "clint@fewbar.com",
+		}},
+		Date:   mustParseTime("2012-06-18T07:54:22-07:00"),
+		Commit: "clint@fewbar.com-20120618145422-ebta2xe3djn55ovf",
+		Revno:  53,
+		Message: `  fixing website relation for providers who set invalid hostnames (local)
+`,
+	}},
+}, {
+	about:   "bad email address",
+	vcsName: "bzr",
+	output: `------------------------------------------------------------
+revno: 58
+author: Foo <Bar@
+committer: Roger Peppe <roger.peppe@canonical.com>
+branch nick: wordpress
+timestamp: Fri 2016-04-15 08:18:19 +0100
+message:
+  something
+`,
+	expectRevisions: []vcsRevision{{
+		Authors: []vcsAuthor{{
+			Name: "Foo <Bar@",
+		}},
+		Date:    mustParseTime("2016-04-15T08:18:19+01:00"),
+		Revno:   58,
+		Message: "  something\n",
+	}},
+}, {
+	about:   "non key-value line in bzr output",
+	vcsName: "bzr",
+	output: `------------------------------------------------------------
+revno: 54
+committer: Clint Byrum <clint@ubuntu.com>
+bad line
+timestamp: Mon 2012-06-18 13:28:16 -0700
+message:
+  x
+`,
+	expectRevisions: []vcsRevision{{
+		Authors: []vcsAuthor{{
+			Name:  "Clint Byrum",
+			Email: "clint@ubuntu.com",
+		}},
+		Date:    mustParseTime("2012-06-18T13:28:16-07:00"),
+		Revno:   54,
+		Message: "  x\n",
+	}},
+}, {
+	about:   "bad timestamp in bzr output",
+	vcsName: "bzr",
+	output: `------------------------------------------------------------
+revno: 54
+committer: Clint Byrum <clint@ubuntu.com>
+bad line
+timestamp: Mon 2012-06-18 13:28:16
+message:
+  Fixing so wordpress is configured as the only thing on port 80
+`,
+	expectError: `cannot parse bzr log entry: parsing time "Mon 2012-06-18 13:28:16" as "Mon 2006-01-02 15:04:05 Z0700": cannot parse "" as "Z0700"`,
+}, {
+	about:   "no message in bzr output",
+	vcsName: "bzr",
+	output: `------------------------------------------------------------
+revno: 54
+committer: Clint Byrum <clint@ubuntu.com>
+`,
+	expectError: "cannot parse bzr log entry: no commit message found in bzr log entry",
+}, {
+	about:   "bzr output with trailer",
+	vcsName: "bzr",
+	output: `------------------------------------------------------------
+revno: 1
+committer: kapil.thangavelu@canonical.com
+branch nick: trunk
+timestamp: Tue 2011-02-01 12:40:51 -0500
+message:
+  wordpress and mysql formulas with tongue in cheek descriptions.
+------------------------------------------------------------
+Use --include-merged or -n0 to see merged revisions.
+`,
+	expectRevisions: []vcsRevision{{
+		Authors: []vcsAuthor{{
+			Email: "kapil.thangavelu@canonical.com",
+		}},
+		Date:  mustParseTime("2011-02-01T12:40:51-05:00"),
+		Revno: 1,
+		Message: `  wordpress and mysql formulas with tongue in cheek descriptions.
+`,
+	}},
+}}
+
+func (s *pushInternalSuite) TestParseLogOutput(c *gc.C) {
+	for i, test := range parseLogOutputTests {
+		c.Logf("test %d: %s", i, test.about)
+		var parse func(output string) ([]vcsRevision, error)
+		for _, p := range vcsLogParsers {
+			if p.name == test.vcsName {
+				parse = p.parse
+				break
+			}
+		}
+		c.Assert(parse, gc.NotNil)
+		revs, err := parse(test.output)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			continue
+		}
+		assertEqualRevisions(c, revs, test.expectRevisions)
+	}
+}
+
+func (s *pushInternalSuite) TestVCSRevisionJSONMarshal(c *gc.C) {
+	rev := vcsRevision{
+		Authors: []vcsAuthor{{
+			Email: "marco@ceppi.net",
+			Name:  "Marco Ceppi",
+		}},
+		Date:    mustParseTime("2015-09-03T18:17:50Z"),
+		Message: "made tags",
+		Commit:  "some-commit",
+		Revno:   84,
+	}
+	data, err := json.Marshal(rev)
+	c.Assert(err, gc.IsNil)
+	var got interface{}
+	err = json.Unmarshal(data, &got)
+	c.Assert(err, gc.IsNil)
+
+	wantJSON := `
+	{
+		"authors": [
+			{
+				"email": "marco@ceppi.net",
+				"name": "Marco Ceppi"
+			}
+		],
+		"date": "2015-09-03T18:17:50Z",
+		"message": "made tags",
+		"commit": "some-commit",
+		"revno": 84
+	}
+	`
+	var want interface{}
+	err = json.Unmarshal([]byte(wantJSON), &want)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(got, jc.DeepEquals, want)
+}
+
+func assertEqualRevisions(c *gc.C, got, want []vcsRevision) {
+	// Deal with times separately because we can't use DeepEquals.
+	wantTimes := make([]time.Time, len(want))
+	for i := range want {
+		wantTimes[i] = want[i].Date
+		want[i].Date = time.Time{}
+	}
+	gotTimes := make([]time.Time, len(got))
+	for i := range got {
+		gotTimes[i] = got[i].Date
+		got[i].Date = time.Time{}
+	}
+	c.Assert(got, jc.DeepEquals, want)
+	for i := range got {
+		if !gotTimes[i].Equal(wantTimes[i]) {
+			c.Errorf("time mismatch in entry %d; got %v want %v", i, gotTimes[i], wantTimes[i])
+		}
+	}
+}
+
+func (s *pushInternalSuite) TestUpdateExtraInfoGit(c *gc.C) {
+	tempDir := c.MkDir()
+	git(c, tempDir, "init")
+
+	err := ioutil.WriteFile(tempDir+"/foo", []byte("bar"), 0600)
+	c.Assert(err, gc.IsNil)
+
+	git(c, tempDir, "config", "user.name", "test")
+	git(c, tempDir, "config", "user.email", "test")
+	git(c, tempDir, "add", "foo")
+	git(c, tempDir, "commit", "-n", "-madd foo")
+
+	extraInfo := getExtraInfo(tempDir)
+	c.Assert(extraInfo, gc.NotNil)
+	commits := extraInfo["vcs-revisions"].([]vcsRevision)
+	c.Assert(len(commits), gc.Equals, 1)
+}
+
+func (s *pushInternalSuite) TestUpdateExtraInfoHg(c *gc.C) {
+	tempDir := c.MkDir()
+	hg(c, tempDir, "init")
+
+	err := ioutil.WriteFile(tempDir+"/foo", []byte("bar"), 0600)
+	c.Assert(err, gc.IsNil)
+
+	hg(c, tempDir, "add", "foo")
+	hg(c, tempDir, "commit", "-madd foo")
+
+	extraInfo := getExtraInfo(tempDir)
+	c.Assert(extraInfo, gc.NotNil)
+	commits := extraInfo["vcs-revisions"].([]vcsRevision)
+	c.Assert(len(commits), gc.Equals, 1)
+}
+
+func (s *pushInternalSuite) TestUpdateExtraInfoBzr(c *gc.C) {
+	tempDir := c.MkDir()
+	bzr(c, tempDir, "init")
+
+	err := ioutil.WriteFile(tempDir+"/foo", []byte("bar"), 0600)
+	c.Assert(err, gc.IsNil)
+
+	bzr(c, tempDir, "whoami", "--branch", "Someone <who@nowhere.com>")
+	bzr(c, tempDir, "add", "foo")
+	bzr(c, tempDir, "commit", "-madd foo")
+
+	extraInfo := getExtraInfo(tempDir)
+	c.Assert(extraInfo, gc.NotNil)
+	commits := extraInfo["vcs-revisions"].([]vcsRevision)
+	c.Assert(commits, gc.HasLen, 1)
+	c.Assert(commits[0].Authors, jc.DeepEquals, []vcsAuthor{{
+		Name:  "Someone",
+		Email: "who@nowhere.com",
+	}})
+	c.Assert(commits[0].Message, gc.Equals, "  add foo\n")
+}
+
+func git(c *gc.C, tempDir string, arg ...string) {
+	runVCS(c, tempDir, "git", arg...)
+}
+
+func hg(c *gc.C, tempDir string, arg ...string) {
+	runVCS(c, tempDir, "hg", arg...)
+}
+
+func bzr(c *gc.C, tempDir string, arg ...string) {
+	runVCS(c, tempDir, "bzr", arg...)
+}
+
+func runVCS(c *gc.C, tempDir, name string, arg ...string) {
+	if !vcsAvailable(name) {
+		c.Skip(name + " command not available")
+	}
+	cmd := exec.Command(name, arg...)
+	cmd.Dir = tempDir
+	out, err := cmd.CombinedOutput()
+	c.Assert(err, gc.IsNil, gc.Commentf("output: %q", out))
+}
+
+var vcsVersionOutput = map[string]string{
+	"bzr": "Bazaar (bzr)",
+	"git": "git version",
+	"hg":  "Mercurial Distributed SCM",
+}
+
+var vcsChecked = make(map[string]bool)
+
+func vcsAvailable(name string) bool {
+	if avail, ok := vcsChecked[name]; ok {
+		return avail
+	}
+	expect := vcsVersionOutput[name]
+	if expect == "" {
+		panic("unknown VCS name")
+	}
+	out, _ := exec.Command(name, "version").CombinedOutput()
+	avail := strings.HasPrefix(string(out), expect)
+	vcsChecked[name] = avail
+	return avail
+}
+
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/cmd/charm/main.go
+++ b/cmd/charm/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"os"
+	"fmt"
 
 	"github.com/juju/cmd"
 	"github.com/juju/juju/juju/osenv"
@@ -14,11 +15,10 @@ import (
 
 func main() {
 	osenv.SetJujuXDGDataHome(osenv.JujuXDGDataHomeDir())
-	ctxt := &cmd.Context{
-		Dir:    ".",
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-		Stdin:  os.Stdin,
+	ctxt, err := cmd.DefaultContext()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
 	}
 	os.Exit(charmcmd.Main(charmcmd.New(), ctxt, os.Args[1:]))
 }


### PR DESCRIPTION
Rather than building a JSON object from interface{} values,
we define a struct type that encodes as we want. We regularise
log parsing somewhat, and increase test coverage including
testing bzr. Rather than second-guessing the PATH value,
we check if the VCS executables aren't there and doing the expected
thing and skip the tests otherwise.

Some behaviour changes too: we format Revno as an integer so we're
backwardly compatible with the old extra-info format, and put the
commit ids into the "commit" field, taking this opportunity to include
the bzr revision ids there too.

Still some work to do (particular bzr commit message parsing) but this'll
do for now.
