### PR TITLE
Prepare for the four channels.

### DIFF
--- a/cmd/charm/charmcmd/attach.go
+++ b/cmd/charm/charmcmd/attach.go
@@ -11,14 +11,13 @@ import (
 	"github.com/juju/cmd"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"launchpad.net/gnuflag"
 )
 
 type attachCommand struct {
 	cmd.CommandBase
 
-	channel string
+	channel chanValue
 	id      *charm.URL
 	name    string
 	file    string
@@ -43,7 +42,7 @@ func (c *attachCommand) Info() *cmd.Info {
 
 func (c *attachCommand) SetFlags(f *gnuflag.FlagSet) {
 	addAuthFlag(f, &c.auth)
-	addChannelFlag(f, &c.channel)
+	addChannelFlag(f, &c.channel, nil)
 }
 
 func (c *attachCommand) Init(args []string) error {
@@ -77,14 +76,11 @@ func (c *attachCommand) Init(args []string) error {
 }
 
 func (c *attachCommand) Run(ctxt *cmd.Context) error {
-	client, err := newCharmStoreClient(ctxt, c.auth)
+	client, err := newCharmStoreClient(ctxt, c.auth, c.channel.C)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}
 	defer client.jar.Save()
-	if c.channel != "" {
-		client.Client = client.Client.WithChannel(params.Channel(c.channel))
-	}
 
 	f, err := os.Open(ctxt.AbsPath(c.file))
 	if err != nil {

--- a/cmd/charm/charmcmd/cmd.go
+++ b/cmd/charm/charmcmd/cmd.go
@@ -111,8 +111,9 @@ func (c *csClient) SaveJAR() error {
 // newCharmStoreClient creates and return a charm store client with access to
 // the associated HTTP client and cookie jar used to save authorization
 // macaroons. If authUsername and authPassword are provided, the resulting
-// client will use HTTP basic auth with the given credentials.
-func newCharmStoreClient(ctxt *cmd.Context, auth authInfo) (*csClient, error) {
+// client will use HTTP basic auth with the given credentials. The charm store
+// client will use the given channel for its operations.
+func newCharmStoreClient(ctxt *cmd.Context, auth authInfo, channel params.Channel) (*csClient, error) {
 	jar, err := cookiejar.New(&cookiejar.Options{
 		PublicSuffixList: publicsuffix.List,
 		Filename:         cookiejar.DefaultCookieFile(),
@@ -138,22 +139,51 @@ func newCharmStoreClient(ctxt *cmd.Context, auth authInfo) (*csClient, error) {
 			BakeryClient: bakeryClient,
 			User:         auth.username,
 			Password:     auth.password,
-		}),
+		}).WithChannel(channel),
 		jar:  jar,
 		ctxt: ctxt,
 	}
 	return &csClient, nil
 }
 
+// addChannelFlag adds the -c (--channel) flags to the given flag set.
+// The channels argument is the set of allowed channels.
+func addChannelFlag(f *gnuflag.FlagSet, cv *chanValue, channels []params.Channel) {
+	if len(channels) == 0 {
+		channels = params.OrderedChannels
+	}
+	chans := make([]string, len(channels))
+	for i, ch := range channels {
+		chans[i] = string(ch)
+	}
+	f.Var(cv, "c", fmt.Sprintf("the channel the charm or bundle is assigned to (%s)", strings.Join(chans, "|")))
+	f.Var(cv, "channel", "")
+}
+
+// chanValue is a gnuflag.Value that stores a channel name
+// ("stable", "candidate", "beta", "edge" or "unpublished").
+type chanValue struct {
+	C params.Channel
+}
+
+// Set implements gnuflag.Value.Set by setting the channel value.
+func (cv *chanValue) Set(s string) error {
+	cv.C = params.Channel(s)
+	if cv.C == params.DevelopmentChannel {
+		logger.Warningf("the development channel is deprecated: automatically switching to the edge channel")
+		cv.C = params.EdgeChannel
+	}
+	return nil
+}
+
+// String implements gnuflag.Value.String.
+func (cv *chanValue) String() string {
+	return string(cv.C)
+}
+
 // addAuthFlag adds the authentication flag to the given flag set.
 func addAuthFlag(f *gnuflag.FlagSet, info *authInfo) {
 	f.Var(info, "auth", "user:passwd to use for basic HTTP authentication")
-}
-
-// addChannelFlag adds the -c (--channel) flags to the given flag set.
-func addChannelFlag(f *gnuflag.FlagSet, s *string) {
-	f.StringVar(s, "c", "", fmt.Sprintf("the channel the charm or bundle is assigned to (%s|%s|%s)", params.StableChannel, params.EdgeChannel, params.UnpublishedChannel))
-	f.StringVar(s, "channel", "", "")
 }
 
 type authInfo struct {

--- a/cmd/charm/charmcmd/cmd_internal_test.go
+++ b/cmd/charm/charmcmd/cmd_internal_test.go
@@ -4,15 +4,18 @@
 package charmcmd
 
 import (
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"launchpad.net/gnuflag"
 )
 
-// cmdInternalSuite includes internal unit tests for non-command-specific functionality.
-type cmdInternalSuite struct{}
+type cmdAuthInfoSuite struct {
+	testing.IsolationSuite
+}
 
-var _ = gc.Suite(&cmdInternalSuite{})
+var _ = gc.Suite(&cmdAuthInfoSuite{})
 
 var authFlagTests = []struct {
 	about       string
@@ -46,7 +49,7 @@ var authFlagTests = []struct {
 	},
 }}
 
-func (*cmdInternalSuite) TestAuthFlag(c *gc.C) {
+func (*cmdAuthInfoSuite) TestAuthFlag(c *gc.C) {
 	for i, test := range authFlagTests {
 		c.Logf("test %d: %s", i, test.about)
 		fs := gnuflag.NewFlagSet("x", gnuflag.ContinueOnError)
@@ -56,8 +59,50 @@ func (*cmdInternalSuite) TestAuthFlag(c *gc.C) {
 		if test.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 		} else {
+			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(info, jc.DeepEquals, test.expect)
 			c.Assert(info.String(), gc.Equals, test.arg)
 		}
 	}
+}
+
+type cmdChanValueSuite struct {
+	testing.IsolationSuite
+	fs      *gnuflag.FlagSet
+	channel chanValue
+}
+
+var _ = gc.Suite(&cmdChanValueSuite{})
+
+func (s *cmdChanValueSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.fs = gnuflag.NewFlagSet("", gnuflag.ContinueOnError)
+	addChannelFlag(s.fs, &s.channel, nil)
+}
+
+func (s *cmdChanValueSuite) run(c *gc.C, channel string) {
+	err := s.fs.Parse(true, []string{"--channel", channel})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *cmdChanValueSuite) TestChannel(c *gc.C) {
+	s.run(c, "beta")
+	c.Assert(s.channel.C, gc.Equals, params.BetaChannel)
+
+	s.run(c, "stable")
+	c.Assert(s.channel.C, gc.Equals, params.StableChannel)
+}
+
+func (s *cmdChanValueSuite) TestString(c *gc.C) {
+	for i, channel := range []string{"stable", "candidate", "beta", "edge", "unpublished"} {
+		c.Logf("\ntest %d: %s", i, channel)
+		s.run(c, channel)
+		c.Assert(s.channel.String(), gc.Equals, channel)
+	}
+}
+
+func (s *cmdChanValueSuite) TestDevelopmentDeprecated(c *gc.C) {
+	s.run(c, "development")
+	c.Assert(s.channel.C, gc.Equals, params.EdgeChannel)
+	c.Assert(c.GetTestLog(), jc.Contains, "the development channel is deprecated: automatically switching to the edge channel")
 }

--- a/cmd/charm/charmcmd/grant.go
+++ b/cmd/charm/charmcmd/grant.go
@@ -21,7 +21,7 @@ type grantCommand struct {
 	auth    authInfo
 	acl     string
 	set     bool
-	channel string
+	channel chanValue
 
 	// Validated options used in Run(...).
 	addReads  []string
@@ -61,7 +61,7 @@ func (c *grantCommand) Info() *cmd.Info {
 
 func (c *grantCommand) SetFlags(f *gnuflag.FlagSet) {
 	addAuthFlag(f, &c.auth)
-	addChannelFlag(f, &c.channel)
+	addChannelFlag(f, &c.channel, nil)
 	f.StringVar(&c.acl, "acl", "read", "read|write")
 	f.BoolVar(&c.set, "set", false, "overwrite the current acl")
 }
@@ -115,15 +115,12 @@ func (c *grantCommand) Init(args []string) error {
 }
 
 func (c *grantCommand) Run(ctxt *cmd.Context) error {
-	client, err := newCharmStoreClient(ctxt, c.auth)
+	client, err := newCharmStoreClient(ctxt, c.auth, c.channel.C)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}
 	defer client.jar.Save()
 
-	if c.channel != "" {
-		client.Client = client.Client.WithChannel(params.Channel(c.channel))
-	}
 	// Perform the request to change the permissions on the charm store.
 	if err := c.changePerms(client); err != nil {
 		return errgo.Mask(err)

--- a/cmd/charm/charmcmd/list.go
+++ b/cmd/charm/charmcmd/list.go
@@ -61,7 +61,7 @@ func (c *listCommand) Init(args []string) error {
 }
 
 func (c *listCommand) Run(ctxt *cmd.Context) error {
-	client, err := newCharmStoreClient(ctxt, c.auth)
+	client, err := newCharmStoreClient(ctxt, c.auth, params.NoChannel)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}

--- a/cmd/charm/charmcmd/listresources.go
+++ b/cmd/charm/charmcmd/listresources.go
@@ -43,7 +43,7 @@ type listResourcesCommand struct {
 	cmd.Output
 
 	id      *charm.URL
-	channel string
+	channel chanValue
 	auth    authInfo
 }
 
@@ -54,7 +54,7 @@ func (c *listResourcesCommand) Info() *cmd.Info {
 
 // SetFlags implements cmd.Command.
 func (c *listResourcesCommand) SetFlags(f *gnuflag.FlagSet) {
-	addChannelFlag(f, &c.channel)
+	addChannelFlag(f, &c.channel, nil)
 	addAuthFlag(f, &c.auth)
 	c.Output.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"json":    cmd.FormatJson,
@@ -82,15 +82,11 @@ func (c *listResourcesCommand) Init(args []string) error {
 
 // Run implements cmd.Command.
 func (c *listResourcesCommand) Run(ctx *cmd.Context) error {
-	client, err := newCharmStoreClient(ctx, c.auth)
+	client, err := newCharmStoreClient(ctx, c.auth, c.channel.C)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}
 	defer client.SaveJAR()
-
-	if c.channel != "" {
-		client.Client = client.Client.WithChannel(params.Channel(c.channel))
-	}
 
 	resources, err := client.Client.ListResources(c.id)
 	if err != nil {

--- a/cmd/charm/charmcmd/login.go
+++ b/cmd/charm/charmcmd/login.go
@@ -6,6 +6,7 @@ package charmcmd
 import (
 	"github.com/juju/cmd"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 )
 
 type loginCommand struct {
@@ -27,7 +28,7 @@ func (c *loginCommand) Info() *cmd.Info {
 }
 
 func (c *loginCommand) Run(ctxt *cmd.Context) error {
-	client, err := newCharmStoreClient(ctxt, authInfo{})
+	client, err := newCharmStoreClient(ctxt, authInfo{}, params.NoChannel)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}

--- a/cmd/charm/charmcmd/logout.go
+++ b/cmd/charm/charmcmd/logout.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/cmd"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon.v1"
 )
 
@@ -40,7 +41,7 @@ func (c *logoutCommand) Run(ctxt *cmd.Context) error {
 	if err := os.Remove(ussoTokenPath()); err != nil && !os.IsNotExist(err) {
 		return errgo.New("cannot remove Ubuntu SSO token")
 	}
-	client, err := newCharmStoreClient(ctxt, authInfo{})
+	client, err := newCharmStoreClient(ctxt, authInfo{}, params.NoChannel)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}

--- a/cmd/charm/charmcmd/push.go
+++ b/cmd/charm/charmcmd/push.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"launchpad.net/gnuflag"
 )
 
@@ -99,7 +100,7 @@ func (c *pushCommand) Init(args []string) error {
 }
 
 func (c *pushCommand) Run(ctxt *cmd.Context) error {
-	client, err := newCharmStoreClient(ctxt, c.auth)
+	client, err := newCharmStoreClient(ctxt, c.auth, params.NoChannel)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}

--- a/cmd/charm/charmcmd/revoke.go
+++ b/cmd/charm/charmcmd/revoke.go
@@ -16,7 +16,7 @@ type revokeCommand struct {
 
 	id      *charm.URL
 	acl     string
-	channel string
+	channel chanValue
 	auth    authInfo
 
 	// Validated options used in Run(...).
@@ -52,7 +52,7 @@ func (c *revokeCommand) Info() *cmd.Info {
 func (c *revokeCommand) SetFlags(f *gnuflag.FlagSet) {
 	addAuthFlag(f, &c.auth)
 	f.StringVar(&c.acl, "acl", "", "read|write")
-	addChannelFlag(f, &c.channel)
+	addChannelFlag(f, &c.channel, nil)
 }
 
 func (c *revokeCommand) Init(args []string) error {
@@ -98,15 +98,12 @@ func (c *revokeCommand) Init(args []string) error {
 }
 
 func (c *revokeCommand) Run(ctxt *cmd.Context) error {
-	client, err := newCharmStoreClient(ctxt, c.auth)
+	client, err := newCharmStoreClient(ctxt, c.auth, c.channel.C)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}
 	defer client.jar.Save()
 
-	if c.channel != "" {
-		client.Client = client.Client.WithChannel(params.Channel(c.channel))
-	}
 	// Perform the request to change the permissions on the charm store.
 	if err := c.changePerms(client); err != nil {
 		return errgo.Mask(err)

--- a/cmd/charm/charmcmd/show.go
+++ b/cmd/charm/charmcmd/show.go
@@ -19,7 +19,7 @@ type showCommand struct {
 	cmd.CommandBase
 
 	out      cmd.Output
-	channel  string
+	channel  chanValue
 	id       *charm.URL
 	includes []string
 	list     bool
@@ -62,7 +62,7 @@ func (c *showCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 	f.BoolVar(&c.list, "list", false, "list available metadata endpoints")
 	addAuthFlag(f, &c.auth)
-	addChannelFlag(f, &c.channel)
+	addChannelFlag(f, &c.channel, nil)
 }
 
 func (c *showCommand) Init(args []string) error {
@@ -88,7 +88,7 @@ func (c *showCommand) Init(args []string) error {
 }
 
 func (c *showCommand) Run(ctxt *cmd.Context) error {
-	client, err := newCharmStoreClient(ctxt, c.auth)
+	client, err := newCharmStoreClient(ctxt, c.auth, c.channel.C)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}
@@ -115,11 +115,6 @@ func (c *showCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	var result params.MetaAnyResponse
-
-	if c.channel != "" {
-		client.Client = client.Client.WithChannel(params.Channel(c.channel))
-	}
-
 	path := "/" + c.id.Path() + "/meta/any?" + query.Encode()
 	if err := client.Get(path, &result); err != nil {
 		return errgo.Notef(err, "cannot get metadata from %s", path)

--- a/cmd/charm/charmcmd/terms.go
+++ b/cmd/charm/charmcmd/terms.go
@@ -68,7 +68,7 @@ type termsResponse struct {
 
 // Run implements cmd.Command.Run.
 func (c *termsCommand) Run(ctxt *cmd.Context) error {
-	client, err := newCharmStoreClient(ctxt, c.auth)
+	client, err := newCharmStoreClient(ctxt, c.auth, params.NoChannel)
 	if err != nil {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}

--- a/cmd/charm/charmcmd/whoami.go
+++ b/cmd/charm/charmcmd/whoami.go
@@ -54,7 +54,7 @@ func (c *whoamiCommand) formatText(value interface{}) ([]byte, error) {
 }
 
 func (c *whoamiCommand) Run(ctxt *cmd.Context) error {
-	client, err := newCharmStoreClient(ctxt, authInfo{})
+	client, err := newCharmStoreClient(ctxt, authInfo{}, params.NoChannel)
 	if err != nil {
 		return errgo.Notef(err, "could not load the cookie from file")
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -39,8 +39,8 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	a3bb92d047b0892452b6a39ece59b4d3a2ac35b9	2016-07-22T08:34:31Z
-gopkg.in/juju/charmrepo.v2-unstable	git	0eff36a3191ee9f2325b202892b0168392974cbe	2016-08-05T14:04:10Z
-gopkg.in/juju/charmstore.v5-unstable	git	1dea8afba3fa78ddd42843457909710428b31728	2016-08-05T14:11:22Z
+gopkg.in/juju/charmrepo.v2-unstable	git	3042f9d7fafb5724e2b4264c585506a52e8c0e51	2016-08-08T08:01:09Z
+gopkg.in/juju/charmstore.v5-unstable	git	89a6843439084d886c47177b49b1587461b0fdf0	2016-08-08T07:52:56Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
 gopkg.in/juju/names.v2	git	e38bc90539f22af61a9c656d35068bd5f0a5b30a	2016-05-25T23:07:23Z


### PR DESCRIPTION
Improve how the channel argument is handled by subcommands.
Also deprecate the "development" channel, automatically translate it to "edge"
and guide the user to start using "edge".
