### PR TITLE
Add term publishing plugin commands to whitelist.

### DIFF
--- a/cmd/charm/charmcmd/plugin.go
+++ b/cmd/charm/charmcmd/plugin.go
@@ -346,10 +346,13 @@ var whiteListedCommands = map[string]bool{
 	"list":           false, // list is an internal command.
 	"promulgate":     false, // promulgate is an internal command.
 	"proof":          true,
+	"push-term":      true,
 	"refresh":        true,
+	"release-term":   true,
 	"review":         true,
 	"review-queue":   true,
 	"search":         true,
+	"show-term":      true,
 	"subscibers":     true,
 	"test":           true,
 	"tools-commands": false, // charm-tools-commands is reserved for whitelist extension.


### PR DESCRIPTION
Note that `publish-term` rename to `release-term` is awaiting review, juju/terms-client#10, but will land soon.
