### PR TITLE
internal/iomon: new package

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -47,7 +47,7 @@ golang.org/x/sys	git	9bb9f0998d48b31547d975974935ae9b48c7a03c	2016-10-12T00:19:2
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
 gopkg.in/juju/charm.v6-unstable	git	25231c01229677e02c5ea0e0ef1c89ee14a200ad	2017-02-22T13:11:15Z
-gopkg.in/juju/charmrepo.v2-unstable	git	18f410ddb935b90bc64f4a5159c6867435cb274c	2017-02-23T10:53:47Z
+gopkg.in/juju/charmrepo.v2-unstable	git	1a5c0d51213a118681812190b1e3e7c574b775e4	2017-02-24T14:29:14Z
 gopkg.in/juju/charmstore.v5-unstable	git	d52b7c3c9d5cca23572da8ef922f8079957d97c0	2017-02-22T11:16:08Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
@@ -60,4 +60,5 @@ gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53
 gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
 gopkg.in/retry.v1	git	c09f6b86ba4d5d2cf5bdf0665364aec9fd4815db	2016-10-25T18:14:30Z
 gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
+gopkg.in/tomb.v2	git	14b3d72120e8d10ea6e6b7f87f7175734b1faab8	2014-06-26T14:46:23Z
 gopkg.in/yaml.v2	git	a83829b6f1293c91addabc89d0571c246397bbf4	2016-03-01T20:40:22Z

--- a/internal/iomon/iomon.go
+++ b/internal/iomon/iomon.go
@@ -1,0 +1,149 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package iomon
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/juju/utils/clock"
+	tomb "gopkg.in/tomb.v2"
+)
+
+const DefaultUpdateInterval = time.Second
+
+// Monitor holds a monitor that continually updates
+// a status value with the current progress of some
+// long IO operation.
+type Monitor struct {
+	tomb tomb.Tomb
+
+	p Params
+
+	// currentStatus is updated by the worker goroutine.
+	currentStatus Status
+
+	mu      sync.Mutex
+	current int64
+}
+
+// Params holds the parameters for creating a new monitor.
+type Params struct {
+	// Size holds the total size of the transfer.
+	Size int64
+
+	// Setter is used to set the current status of
+	// the transfer.
+	Setter StatusSetter
+
+	// UpdateInterval controls how often a status update will be
+	// sent. It it's zero, DefaultUpdateInterval will be used.
+	UpdateInterval time.Duration
+
+	// Clock is used as a source of timing information.
+	// If it is nil, the global time will be used.
+	Clock clock.Clock
+}
+
+// New returns a new running monitor using the given parameters. The
+// Monitor should be stopped by calling Kill when the transfer is
+// complete.
+// Note that Monitor implements the worker.Worker interface
+// (see gopkg.in/juju/worker.v1).
+func New(p Params) *Monitor {
+	if p.UpdateInterval == 0 {
+		p.UpdateInterval = DefaultUpdateInterval
+	}
+	if p.Clock == nil {
+		p.Clock = clock.WallClock
+	}
+	m := &Monitor{
+		p: p,
+	}
+	m.tomb.Go(m.run)
+	return m
+}
+
+// Kill kills the monitor but does not wait for it to exit.
+func (m *Monitor) Kill() {
+	m.tomb.Kill(nil)
+}
+
+// Wait waits for the monitor to exit. When this returns, SetStatus will
+// no longer be called. It never returns a non-nil error status - the
+// error return is so that it implements the worker.Worker interface.
+func (m *Monitor) Wait() error {
+	m.tomb.Wait()
+	return nil
+}
+
+// Update sets the current number of transferred bytes.
+func (m *Monitor) Update(current int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.current = current
+}
+
+// Status indicates the current status of the I/O transfer.
+type Status struct {
+	// Current holds the current number of transferred bytes.
+	Current int64
+	// Total holds the total number of bytes in the transfer.
+	Total int64
+
+	// TODO add rate, expected time
+}
+
+// StatusSetter is used to indicate the current progress status.
+type StatusSetter interface {
+	SetStatus(s Status)
+}
+
+func (m *Monitor) run() error {
+	for {
+		m.setStatus()
+		select {
+		case <-m.p.Clock.After(m.p.UpdateInterval):
+		case <-m.tomb.Dying():
+			// Always set the final status when finishing.
+			m.setStatus()
+			return nil
+		}
+	}
+}
+
+func (m *Monitor) setStatus() {
+	m.mu.Lock()
+	current := m.current
+	m.mu.Unlock()
+	status := Status{
+		Current: current,
+		Total:   m.p.Size,
+	}
+	if status != m.currentStatus {
+		m.p.Setter.SetStatus(status)
+		m.currentStatus = status
+	}
+}
+
+const (
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+)
+
+// FormatByteCount returns a string representation of
+// the given number formatted so as to be user readable
+// in progress reports.
+func FormatByteCount(n int64) string {
+	switch {
+	case n < 10*MiB:
+		return fmt.Sprintf("%.0fKiB", float64(n)/KiB)
+	case n < 10*GiB:
+		return fmt.Sprintf("%.1fMiB", float64(n)/MiB)
+	default:
+		return fmt.Sprintf("%.1fGiB", float64(n)/GiB)
+	}
+}

--- a/internal/iomon/iomon_test.go
+++ b/internal/iomon/iomon_test.go
@@ -1,0 +1,103 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package iomon_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/charmstore-client/internal/iomon"
+)
+
+type iomonSuite struct{}
+
+var _ = gc.Suite(&iomonSuite{})
+
+func (*iomonSuite) TestMonitor(c *gc.C) {
+	setterCh := make(statusSetter)
+	t0 := time.Now()
+	clock := testing.NewClock(t0)
+	m := iomon.New(iomon.Params{
+		Size:           1000,
+		Setter:         setterCh,
+		UpdateInterval: time.Second,
+		Clock:          clock,
+	})
+	c.Assert(setterCh.wait(c), jc.DeepEquals, iomon.Status{
+		Current: 0,
+		Total:   1000,
+	})
+	clock.Advance(time.Second)
+	// Nothing changed, so no status should be sent.
+	setterCh.expectNothing(c)
+	// Calling update should not trigger a status send.
+	m.Update(500)
+	setterCh.expectNothing(c)
+	clock.Advance(time.Second)
+	c.Assert(setterCh.wait(c), jc.DeepEquals, iomon.Status{
+		Current: 500,
+		Total:   1000,
+	})
+	// Updating to the same value should not trigger a status send.
+	m.Update(500)
+	clock.Advance(time.Second)
+	setterCh.expectNothing(c)
+
+	m.Update(700)
+	m.Kill()
+	// One last status update should be sent when it's killed.
+	c.Assert(setterCh.wait(c), jc.DeepEquals, iomon.Status{
+		Current: 700,
+		Total:   1000,
+	})
+	m.Wait()
+	clock.Advance(10 * time.Second)
+	setterCh.expectNothing(c)
+}
+
+var formatByteCountTests = []struct {
+	n      int64
+	expect string
+}{
+	{0, "0KiB"},
+	{2567, "3KiB"},
+	{9876 * 1024, "9876KiB"},
+	{10 * 1024 * 1024, "10.0MiB"},
+	{20 * 1024 * 1024 * 1024, "20.0GiB"},
+	{55068359375, "51.3GiB"},
+}
+
+func (*iomonSuite) TestFormatByteCount(c *gc.C) {
+	for i, test := range formatByteCountTests {
+		c.Logf("test %d: %v", i, test.n)
+		c.Assert(iomon.FormatByteCount(test.n), gc.Equals, test.expect)
+	}
+}
+
+type statusSetter chan iomon.Status
+
+func (ch statusSetter) wait(c *gc.C) iomon.Status {
+	select {
+	case s := <-ch:
+		return s
+	case <-time.After(5 * time.Second):
+		c.Fatalf("timed out waiting for status")
+		panic("unreachable")
+	}
+}
+
+func (ch statusSetter) expectNothing(c *gc.C) {
+	select {
+	case s := <-ch:
+		c.Fatalf("unexpected status received %#v", s)
+	case <-time.After(10 * time.Millisecond):
+	}
+}
+
+func (ch statusSetter) SetStatus(s iomon.Status) {
+	ch <- s
+}

--- a/internal/iomon/package_test.go
+++ b/internal/iomon/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package iomon_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This will provide the mechanism behind printing I/O progress
updates to the command line. It's designed so that we can update
it with current transfer rate at a future date, and also so that
it could be externally reusable.

[Previously proposed as https://github.com/juju/charmrepo/pull/115]