### PR TITLE
charm attach - error on missing revision

### DIFF
--- a/cmd/charm/charmcmd/attach.go
+++ b/cmd/charm/charmcmd/attach.go
@@ -26,7 +26,13 @@ type attachCommand struct {
 var attachDoc = `
 The attach command uploads a file as a new resource for a charm.
 
-   charm attach ~user/trusty/wordpress website-data=./foo.zip
+    charm attach ~user/trusty/wordpress-0 website-data=./foo.zip
+
+The default channel is the stable channel. A revision number is required
+when using the stable channel. A revision number is not required when
+using another channel.
+
+    charm attach ~user/mycharm mydata=./blah -c unpublished
 
 `
 
@@ -80,6 +86,10 @@ func (c *attachCommand) Run(ctxt *cmd.Context) error {
 		return errgo.Notef(err, "cannot create the charm store client")
 	}
 	defer client.jar.Save()
+
+	if (c.channel.C == "" || c.channel.C == "stable") && c.id.Revision == -1 {
+		return errgo.New("A revision is required when attaching to a charm in the stable channel.")
+	}
 
 	rev, err := uploadResource(ctxt, client.Client, c.id, c.name, c.file)
 	if err != nil {

--- a/cmd/charm/charmcmd/attach_test.go
+++ b/cmd/charm/charmcmd/attach_test.go
@@ -94,6 +94,17 @@ func (s *attachSuite) TestRun(c *gc.C) {
 	}})
 }
 
+func (s *attachSuite) TestRunFailsWithoutRevisionOnStableChannel(c *gc.C) {
+	dir := c.MkDir()
+	err := ioutil.WriteFile(filepath.Join(dir, "bar.zip"), []byte("content"), 0666)
+	c.Assert(err, gc.IsNil)
+	stdout, stderr, exitCode := run(dir, "attach", "--channel=stable", "~bob/precise/wordpress", "someResource=bar.zip")
+	c.Assert(exitCode, gc.Equals, 1)
+	c.Check(stderr, gc.Matches, "ERROR A revision is required when attaching to a charm in the stable channel.\n")
+	c.Check(stdout, gc.Matches, "")
+
+}
+
 func hashOfString(s string) []byte {
 	x := sha512.Sum384([]byte(s))
 	return x[:]
@@ -101,7 +112,7 @@ func hashOfString(s string) []byte {
 
 func (s *attachSuite) TestCannotOpenFile(c *gc.C) {
 	path := filepath.Join(c.MkDir(), "/not-there")
-	stdout, stderr, exitCode := run(c.MkDir(), "attach", "wordpress", "foo="+path)
+	stdout, stderr, exitCode := run(c.MkDir(), "attach", "wordpress-0", "foo="+path)
 	c.Assert(exitCode, gc.Equals, 1)
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Matches, `ERROR open .*not-there: no such file or directory`+"\n")

--- a/cmd/charm/charmcmd/whoami_test.go
+++ b/cmd/charm/charmcmd/whoami_test.go
@@ -41,7 +41,7 @@ func (s *whoamiSuite) SetUpTest(c *gc.C) {
 	s.serverParams = charmstore.ServerParams{
 		AuthUsername:     "test-user",
 		AuthPassword:     "test-password",
-		IdentityAPIURL:   s.idsrv.URL.String(),
+		IdentityLocation: s.idsrv.URL.String(),
 		PublicKeyLocator: s.idsrv,
 		AgentUsername:    "test-user",
 		AgentKey:         s.idsrv.UserPublicKey("test-user"),


### PR DESCRIPTION
This prevents potentially large upload which will then return a revision required error.