### PR TITLE
charmcmd/terms: Consolidate terms and list-terms command into more sensible names, and not rely on plugins

### DIFF
--- a/cmd/charm/charmcmd/cmd.go
+++ b/cmd/charm/charmcmd/cmd.go
@@ -86,6 +86,7 @@ func New() *cmd.SuperCommand {
 	c.Register(termscmd.NewReleaseTermCommand())
 	c.Register(termscmd.NewPushTermCommand())
 	c.Register(termscmd.NewShowTermCommand())
+	c.Register(termscmd.NewListTermsCommand())
 
 	// Register plans-client commands
 	c.Register(planscmd.NewAttachCommand())

--- a/cmd/charm/charmcmd/terms.go
+++ b/cmd/charm/charmcmd/terms.go
@@ -23,27 +23,16 @@ type termsCommand struct {
 	user string
 }
 
-// TODO (mattyw) As of 16Mar2016 this is implemented
-// in a different way to the description here, but the
-// description here shows the intent. The implementation
-// will need to be improved when it is supported in the
-// terms service.
-// The implemenation as of 16Mar2016 simply iterates over
-// the charms owned by the user and then gets a list of the
-// terms required by these charms. Using this it then produces
-// a mapping of term:[]charmUrl to be output to the user.
 var termsDoc = `
-The terms command lists the terms owned by this user and the
-charms that require these terms to b agreed to.
-
-   charm terms
+lists the terms required by the current user's charms
+   charm terms-used
 `
 
 // Info implements cmd.Command.Info.
 func (c *termsCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "terms",
-		Purpose: "lists terms owned by the user",
+		Name:    "terms-used",
+		Purpose: "list terms required by current user's charms",
 		Doc:     termsDoc,
 	}
 }

--- a/cmd/charm/charmcmd/terms_test.go
+++ b/cmd/charm/charmcmd/terms_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&termsSuite{})
 
 func (s *termsSuite) TestInvalidServerURL(c *gc.C) {
 	os.Setenv("JUJU_CHARMSTORE", "#%zz")
-	stdout, stderr, exitCode := run(c.MkDir(), "terms")
+	stdout, stderr, exitCode := run(c.MkDir(), "terms-used")
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(exitCode, gc.Equals, 1)
 	c.Assert(stderr, gc.Equals, "ERROR cannot retrieve identity: parse #%zz/v5/whoami: invalid URL escape \"%zz\"\n")
@@ -41,7 +41,7 @@ func (s *termsSuite) TestTermsUserProvidedYAML(c *gc.C) {
 	s.uploadCharmDir(c, charm.MustParseURL("~test-user/trusty/alambic-0"), -1, entitytesting.Repo.CharmDir("terms2"))
 	s.uploadCharmDir(c, charm.MustParseURL("~someoneelse/trusty/alambic-0"), -1, entitytesting.Repo.CharmDir("terms1"))
 	dir := c.MkDir()
-	stdout, stderr, code := run(dir, "terms", "-u", "test-user", "--format", "yaml")
+	stdout, stderr, code := run(dir, "terms-used", "-u", "test-user", "--format", "yaml")
 	c.Assert(stderr, gc.Equals, "")
 
 	c.Assert(stdout, gc.Equals, `term1/1:
@@ -63,7 +63,7 @@ func (s *termsSuite) TestTermsUserProvidedTabular(c *gc.C) {
 	s.uploadCharmDir(c, charm.MustParseURL("~test-user/trusty/alambic-0"), -1, entitytesting.Repo.CharmDir("terms2"))
 	s.uploadCharmDir(c, charm.MustParseURL("~someoneelse/trusty/alambic-0"), -1, entitytesting.Repo.CharmDir("terms1"))
 	dir := c.MkDir()
-	stdout, stderr, code := run(dir, "terms", "-u", "test-user")
+	stdout, stderr, code := run(dir, "terms-used", "-u", "test-user")
 	c.Assert(stderr, gc.Equals, "")
 
 	c.Assert(stdout, gc.Equals, `TERM   	CHARM                         
@@ -84,7 +84,7 @@ func (s *termsSuite) TestTermsUserProvidedEmpty(c *gc.C) {
 	s.uploadCharmDir(c, charm.MustParseURL("~test-user/trusty/alambic-0"), -1, entitytesting.Repo.CharmDir("terms2"))
 	s.uploadCharmDir(c, charm.MustParseURL("~someoneelse/trusty/alambic-0"), -1, entitytesting.Repo.CharmDir("terms1"))
 	dir := c.MkDir()
-	stdout, stderr, code := run(dir, "terms", "-u", "test-user", "--format", "yaml")
+	stdout, stderr, code := run(dir, "terms-used", "-u", "test-user", "--format", "yaml")
 	c.Assert(stderr, gc.Equals, "")
 	c.Assert(stdout, gc.Equals, `term1/1:
 - cs:~test-user/trusty/alambic-0
@@ -96,7 +96,7 @@ term2/1:
 }
 
 func (s *termsSuite) TestUnknownArgument(c *gc.C) {
-	stdout, stderr, code := run(c.MkDir(), "terms", "-u", "test-user", "foobar")
+	stdout, stderr, code := run(c.MkDir(), "terms-used", "-u", "test-user", "foobar")
 	c.Assert(code, gc.Equals, 2)
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, `ERROR unrecognized args: ["foobar"]
@@ -104,7 +104,7 @@ func (s *termsSuite) TestUnknownArgument(c *gc.C) {
 }
 
 func (s *termsSuite) TestNoTerms(c *gc.C) {
-	stdout, stderr, code := run(c.MkDir(), "terms", "-u", "test-user")
+	stdout, stderr, code := run(c.MkDir(), "terms-used", "-u", "test-user")
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(stdout, gc.Equals, "No terms found.\n")
 	c.Assert(stderr, gc.Equals, "")

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -24,7 +24,7 @@ github.com/juju/persistent-cookiejar	git	d67418f14c93a698e37b52468958d5d4dcf8a7d
 github.com/juju/plans-client	git	258586f997a6c43d4443c31fbb00c2278e51f406	2017-11-30T10:18:50Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
-github.com/juju/terms-client	git	147daeb1fb3697d65c5691b1e574119683b37df8	2017-05-10T12:02:29Z
+github.com/juju/terms-client	git	68c3a74aeab3633d1eede0c98a1ef62d59cbf6be	2017-12-04T17:53:31Z
 github.com/juju/testing	git	06d21ddace802a83d08c82f513e30d84010ce31f	2017-05-01T02:35:42Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z


### PR DESCRIPTION
What was charm list-terms is now charm terms <- finally bringing it inline with the original spec (see the removed comment for details). It also now exists as a first class subcommand rather than a plugin.

What was charm terms is now called term-use. This command doesn't appear in any spec, but existed as a workaround to get around historical group limitations in the IDM. Rather than remove this command we keep it under a new name.