### PR TITLE
cmd/charm/charmcmd: implement resource upload resumption

### DIFF
--- a/cmd/charm/charmcmd/cmd_test.go
+++ b/cmd/charm/charmcmd/cmd_test.go
@@ -112,16 +112,19 @@ func (s *commonSuite) TearDownTest(c *gc.C) {
 	s.IsolatedMgoSuite.TearDownTest(c)
 }
 
+const minUploadPartSize = 100 * 1024
+
 func (s *commonSuite) startServer(c *gc.C, session *mgo.Session) {
 	s.discharger = idmtest.NewServer()
 	s.discharger.AddUser("charmstoreuser")
 	s.serverParams = charmstore.ServerParams{
-		AuthUsername:     "test-user",
-		AuthPassword:     "test-password",
-		IdentityLocation: s.discharger.URL.String(),
-		AgentKey:         bakery2uKeyPair(s.discharger.UserPublicKey("charmstoreuser")),
-		AgentUsername:    "charmstoreuser",
-		PublicKeyLocator: bakeryV2LocatorToV2uLocator{s.discharger},
+		AuthUsername:      "test-user",
+		AuthPassword:      "test-password",
+		IdentityLocation:  s.discharger.URL.String(),
+		AgentKey:          bakery2uKeyPair(s.discharger.UserPublicKey("charmstoreuser")),
+		AgentUsername:     "charmstoreuser",
+		PublicKeyLocator:  bakeryV2LocatorToV2uLocator{s.discharger},
+		MinUploadPartSize: minUploadPartSize,
 	}
 	var err error
 	s.handler, err = charmstore.NewServer(session.DB("charmstore"), nil, "", s.serverParams, charmstore.V5)

--- a/cmd/charm/charmcmd/push_test.go
+++ b/cmd/charm/charmcmd/push_test.go
@@ -312,19 +312,17 @@ func (s *pushSuite) TestUploadCharmWithResources(c *gc.C) {
 		"~bob/trusty/something",
 		"--resource", "data=data.zip",
 		"--resource", "website=web.html")
-	c.Assert(stderr, gc.Matches, "")
+	c.Assert(stderr, gc.Matches, `(\r.*data\.zip.*)+\n(\r.*web\.html.*)+\n`)
 	c.Assert(code, gc.Equals, 0)
 
 	expectOutput := fmt.Sprintf(`
 url: cs:~bob/trusty/something-0
 channel: unpublished
-((\r.*)+
-)?Uploaded %q as data-0
-((\r.*)+
-)?Uploaded %q as website-0
+Uploaded %q as data-0
+Uploaded %q as website-0
 `[1:], dataPath, websitePath,
 	)
-	c.Assert(stdout, gc.Matches, expectOutput)
+	c.Assert(stdout, gc.Equals, expectOutput)
 
 	client := s.client.WithChannel(params.UnpublishedChannel)
 	resources, err := client.ListResources(charm.MustParseURL("cs:~bob/trusty/something-0"))

--- a/cmd/charm/charmcmd/uploadidcache.go
+++ b/cmd/charm/charmcmd/uploadidcache.go
@@ -1,0 +1,138 @@
+package charmcmd
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/juju/utils"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v6"
+)
+
+type UploadIdCache struct {
+	dir            string
+	expiryDuration time.Duration
+}
+
+func NewUploadIdCache(dir string, expiryDuration time.Duration) *UploadIdCache {
+	return &UploadIdCache{
+		dir:            dir,
+		expiryDuration: expiryDuration,
+	}
+}
+
+type UploadIdCacheEntry struct {
+	CharmURL     *charm.URL
+	ResourceName string
+	ResourceHash string
+	Size         int64
+	CreatedDate  time.Time
+	UploadId     string
+}
+
+var errCacheEntryNotFound = errgo.New("no upload cache entry found")
+
+// lookup returns the entry for the given charm URL, resource name and content hash
+// the SHA256 of the content), or an error with an errCacheEntryNotFound cause if none was found.
+func (c *UploadIdCache) Lookup(curl *charm.URL, resourceName string, contentHash []byte) (*UploadIdCacheEntry, error) {
+	return c.readEntry(c.filename(curl, resourceName, contentHash))
+}
+
+func (c *UploadIdCache) Update(uploadId string, curl *charm.URL, resourceName string, resourceHash []byte) error {
+	if err := os.MkdirAll(c.dir, 0777); err != nil {
+		return errgo.Notef(err, "cannot create uploadId cache entry")
+	}
+	data, err := json.Marshal(UploadIdCacheEntry{
+		CharmURL:     curl,
+		ResourceName: resourceName,
+		ResourceHash: fmt.Sprintf("%x", resourceHash),
+		UploadId:     uploadId,
+		CreatedDate:  time.Now(),
+	})
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	// If we have two charm command instances both uploading a resource
+	// with the same contents at the same time, we'll only record one of the
+	// uploadIds for later resumption, but that should be fine.
+	if err := utils.AtomicWriteFile(c.filename(curl, resourceName, resourceHash), data, 0666); err != nil {
+		return errgo.Mask(err)
+	}
+	return nil
+}
+
+// Remove removes the entry for the given charm, resource and hash.
+func (c *UploadIdCache) Remove(curl *charm.URL, resourceName string, resourceHash []byte) error {
+	err := os.Remove(c.filename(curl, resourceName, resourceHash))
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	return errgo.Mask(err)
+}
+
+// RemoveExpiredEntries removes all expired entries from the cache.
+func (c *UploadIdCache) RemoveExpiredEntries() error {
+	entries, err := ioutil.ReadDir(c.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errgo.Mask(err)
+	}
+	for _, entry := range entries {
+		if !entry.Mode().IsRegular() || !strings.HasSuffix(entry.Name(), ".up") {
+			continue
+		}
+		// Note that readEntry removes corrupt or out of date entries.
+		if _, err := c.readEntry(filepath.Join(c.dir, entry.Name())); err != nil && errgo.Cause(err) != errCacheEntryNotFound {
+			return errgo.Mask(err)
+		}
+	}
+	return nil
+}
+
+// readEntry returns the cache entry at the given path, or an error with
+// a errCacheEntryNotFound cause if an entry was not found or the
+// existing entry has expired or is corrupt (in the latter two case, readEntry
+// will remove the entry).
+func (c *UploadIdCache) readEntry(path string) (*UploadIdCacheEntry, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errCacheEntryNotFound
+		}
+		return nil, errgo.Mask(err)
+	}
+	var entry UploadIdCacheEntry
+	err = json.Unmarshal(data, &entry)
+	if err != nil {
+		// corrupt entry. remove it.
+		logger.Warningf("removing corrupt upload ID cache entry %q", path)
+	}
+	if err != nil || entry.CreatedDate.Before(time.Now().Add(-c.expiryDuration)) {
+		// Note that if we've got two commands doing this simultaneously, they
+		// might both read the directory and then only one of then will succeed
+		// in removing the file, so be resilient by checking for the IsNotExist error.
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return nil, errgo.Notef(err, "cannot remove upload ID cache entry")
+		}
+		return nil, errCacheEntryNotFound
+	}
+	return &entry, nil
+}
+
+// filename returns the file name to use for an upload to the given charm URL, resource
+// name and resource content SHA256 hash.
+func (c *UploadIdCache) filename(curl *charm.URL, resourceName string, resourceHash []byte) string {
+	sum := sha256.New()
+	sum.Write([]byte(curl.WithRevision(-1).String() + "\n"))
+	sum.Write([]byte(resourceName + "\n"))
+	sum.Write(resourceHash)
+	return filepath.Join(c.dir, fmt.Sprintf("%x.up", sum.Sum(nil)))
+}

--- a/cmd/charm/charmcmd/whoami_test.go
+++ b/cmd/charm/charmcmd/whoami_test.go
@@ -8,10 +8,11 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/juju/charmstore-client/cmd/charm/charmcmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	yaml "gopkg.in/yaml.v1"
+
+	"github.com/juju/charmstore-client/cmd/charm/charmcmd"
 )
 
 type whoamiSuite struct {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -4,7 +4,7 @@ github.com/cloud-green/monitoring	git	666e3beca3cb4f6b5c8f176ba80daf2b3adbd84e	2
 github.com/golang/protobuf	git	925541529c1fa6821df4e44ce2723319eb2be768	2018-01-25T21:43:03Z
 github.com/gosuri/uitable	git	36ee7e946282a3fb1cfecd476ddc9b35d8847e42	2016-04-04T20:39:58Z
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
-github.com/juju/cmd	git	e74f39857ca013cf63947ba2843806f7afdd380d	2017-11-07T07:04:56Z
+github.com/juju/cmd	git	c766ef3f2a8296463b28a65e2ef388447efe212c	2018-05-18T10:01:08Z
 github.com/juju/errors	git	c7d06af17c68cd34c835053720b21f6549d9b0ee	2017-07-03T01:00:42Z
 github.com/juju/gnuflag	git	2ce1bb71843d6d179b3f1c1c9cb4a72cd067fc65	2017-11-13T08:59:48Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z
@@ -37,7 +37,7 @@ github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-
 github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 github.com/matttproud/golang_protobuf_extensions	git	c12348ce28de40eed0136aa2b644d0ee0650e56c	2016-04-24T11:30:07Z
-github.com/prometheus/client_golang	git	c5b7fccd204277076155f10851dad72b76a49317	2016-08-17T15:48:24Z
+github.com/prometheus/client_golang	git	575f371f7862609249a1be4c9145f429fe065e32	2016-11-24T15:57:32Z
 github.com/prometheus/client_model	git	99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c	2017-11-17T10:05:41Z
 github.com/prometheus/common	git	6fb6fce6f8b75884b92e1889c150403fc0872c5e	2018-02-28T09:25:48Z
 github.com/prometheus/procfs	git	d274e363d5759d1c916232217be421f1cc89c5fe	2018-02-28T15:07:32Z
@@ -52,11 +52,11 @@ gopkg.in/httprequest.v1	git	3531529dedf047a744dd77f5262515aefff8cd48	2018-03-19T
 gopkg.in/juju/charm.v6	git	96786fc3f8695207515eb6be307ff37901a7254f	2018-01-19T23:10:43Z
 gopkg.in/juju/charm.v6-unstable	git	514bb811b021ebeb3e7ffcf1c267e9803968f59d	2017-07-28T19:41:00Z
 gopkg.in/juju/charmrepo.v2-unstable	git	e79aa298df89ea887c9bffec46063c24bfb730f7	2016-11-17T15:25:28Z
-gopkg.in/juju/charmrepo.v3	git	7f799297ba8d526feb52630477bd44e71037f92e	2018-04-11T22:45:32Z
-gopkg.in/juju/charmrepo.v4	git	b3e6d25ec168d36c0c66e5174cb6731820693248	2018-05-01T08:52:32Z
-gopkg.in/juju/charmstore.v5	git	b247403557f8622e3ea64bd31e9ad569379daf08	2018-05-01T08:35:10Z
+gopkg.in/juju/charmrepo.v3	git	3d036d99fb5c12f98e017093a4a7c85433ac9578	2018-05-11T16:22:30Z
+gopkg.in/juju/charmrepo.v4	git	773a31e1493c1c9a6f66326663f438b65e37145c	2018-05-18T08:52:29Z
+gopkg.in/juju/charmstore.v5	git	1920a2dc155027fb194122b5487a8435b8480355	2018-05-16T16:11:04Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
-gopkg.in/juju/idmclient.v1	git	e35a92586d090fc2675f1db551ebae4184a43d64	2017-11-10T11:12:44Z
+gopkg.in/juju/idmclient.v1	git	203d20774ce8aeaa6f662ee0b48f8cb5bc0816a1	2018-03-20T16:18:56Z
 gopkg.in/juju/jujusvg.v3	git	6f7342099e20c84f560bd9fc8afe96ff7486613e	2017-11-14T17:07:01Z
 gopkg.in/juju/names.v2	git	54f00845ae470a362430a966fe17f35f8784ac92	2017-11-13T11:20:47Z
 gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
@@ -67,7 +67,7 @@ gopkg.in/macaroon.v1	git	ab101776739ee61baab9bc50e4b33b5aeb3ac843	2017-08-16T14:
 gopkg.in/macaroon.v2	git	bed2a428da6e56d950bed5b41fcbae3141e5b0d0	2017-10-17T15:30:37Z
 gopkg.in/macaroon.v2-unstable	git	66ab28d0d56f39a383f7cf5cf3ac9a4e9ab32865	2018-03-09T13:12:17Z
 gopkg.in/mgo.v2	git	3f83fa5005286a7fe593b055f0d7771a7dce4655	2016-08-18T02:01:20Z
-gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
+gopkg.in/natefinch/lumberjack.v2	git	df99d62fd42d8b3752c8a42c6723555372c02a03	2017-05-31T18:08:50Z
 gopkg.in/retry.v1	git	2d7c7c65cc71d024968d9ff4385d5e7ad3a83fcc	2018-01-16T15:34:15Z
 gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
 gopkg.in/tomb.v2	git	d5d1b5820637886def9eef33e03a27a9f166942c	2016-12-08T15:16:19Z


### PR DESCRIPTION
We keep a local cache of upload information so that we can automatically resume uploads if they're aborted.