### PR TITLE
cmd/charm/charmcmd: support adding external docker image resources

### DIFF
--- a/cmd/charm/charmcmd/attach.go
+++ b/cmd/charm/charmcmd/attach.go
@@ -35,6 +35,20 @@ using another channel.
 
     charm attach ~user/mycharm mydata=./blah -c unpublished
 
+The attach command can also be used to attach docker resources
+to Kubernetes charms. When a charm has a docker image resource,
+it can be attached by naming the image in the local docker instance:
+
+    charm attach ~user/mykubernetes-charm myresource=ubuntu
+
+The image will be uploaded to the Docker registry associated with the
+charm store. It's also possible to attach an image from an external
+registry directly without uploading it to the charmstore's registry
+by using the prefix "external::"; for example:
+
+    charm attach ~user/mykubernetes-charm myresource=external::ubuntu
+
+Such external images must be publicly accessible.
 `
 
 func (c *attachCommand) Info() *cmd.Info {

--- a/cmd/charm/charmcmd/push.go
+++ b/cmd/charm/charmcmd/push.go
@@ -57,7 +57,8 @@ repeated more than once to upload more than one resource.
   charm push . --resource website=~/some/file.tgz --resource config=./docs/cfg.xml
 
 See also the attach subcommand, which can be used to push resources
-independently of a charm.
+independently of a charm; its help also includes more details on Docker
+image resources for Kubernetes charms.
 `
 
 func (c *pushCommand) Info() *cmd.Info {


### PR DESCRIPTION
This checks that the image is available before telling the charm store about it.
