### PR TITLE
cmd/charm/charmcmd: remove USSO auth

### DIFF
--- a/cmd/charm/charmcmd/export_test.go
+++ b/cmd/charm/charmcmd/export_test.go
@@ -8,8 +8,6 @@ var (
 	CSClientServerURL                      = &csclientServerURL
 	PluginTopicText                        = pluginTopicText
 	ServerURL                              = serverURL
-	TranslateError                         = translateError
-	USSOTokenPath                          = ussoTokenPath
 	PluginDescriptionLastCallReturnedCache = &pluginDescriptionLastCallReturnedCache
 	WhiteListedCommands                    = whiteListedCommands
 )

--- a/cmd/charm/charmcmd/login.go
+++ b/cmd/charm/charmcmd/login.go
@@ -39,5 +39,5 @@ func (c *loginCommand) Run(ctxt *cmd.Context) error {
 		return errgo.Notef(err, "cannot create charm store client")
 	}
 	defer client.jar.Save()
-	return translateError(client.Login())
+	return errgo.Mask(client.Login())
 }

--- a/cmd/charm/charmcmd/logout.go
+++ b/cmd/charm/charmcmd/logout.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -37,10 +36,6 @@ func (c *logoutCommand) Info() *cmd.Info {
 }
 
 func (c *logoutCommand) Run(ctxt *cmd.Context) error {
-	// Delete any Ubuntu SSO token.
-	if err := os.Remove(ussoTokenPath()); err != nil && !os.IsNotExist(err) {
-		return errgo.New("cannot remove Ubuntu SSO token")
-	}
 	client, err := newCharmStoreClient(ctxt, authInfo{}, params.NoChannel)
 	if err != nil {
 		return errgo.Notef(err, "cannot create charm store client")

--- a/cmd/charm/charmcmd/logout_test.go
+++ b/cmd/charm/charmcmd/logout_test.go
@@ -10,11 +10,8 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/persistent-cookiejar"
 	"golang.org/x/net/publicsuffix"
-
-	"github.com/juju/charmstore-client/cmd/charm/charmcmd"
 )
 
 type logoutSuite struct {
@@ -53,22 +50,6 @@ func (s *logoutSuite) TestWithCookie(c *qt.C) {
 	s.checkNoUser(c)
 }
 
-func (s *logoutSuite) TestWithToken(c *qt.C) {
-	s.discharger.SetDefaultUser("test-user")
-	f, err := os.Create(osenv.JujuXDGDataHomePath("store-usso-token"))
-	c.Assert(err, qt.Equals, nil)
-	_, err = f.Write([]byte("TEST!"))
-	c.Assert(err, qt.Equals, nil)
-	c.Assert(f.Close(), qt.Equals, nil)
-	c.Assert(isNonEmptyFile(charmcmd.USSOTokenPath()), qt.Equals, true)
-	dir := c.Mkdir()
-	stdout, stderr, code := run(dir, "logout")
-	c.Assert(stdout, qt.Equals, "")
-	c.Assert(stderr, qt.Matches, "")
-	c.Assert(code, qt.Equals, 0)
-	s.checkNoUser(c)
-}
-
 func (s *logoutSuite) checkNoUser(c *qt.C) {
 	s.discharger.SetDefaultUser("test-user")
 	jar, err := cookiejar.New(&cookiejar.Options{
@@ -82,7 +63,6 @@ func (s *logoutSuite) checkNoUser(c *qt.C) {
 	for _, cookie := range cookies {
 		c.Assert(strings.HasPrefix(cookie.Name, "macaroon-"), qt.Equals, false, qt.Commentf("cookie %s found", cookie.Name))
 	}
-	c.Assert(fileExists(charmcmd.USSOTokenPath()), qt.Equals, false)
 }
 
 func isNonEmptyFile(path string) bool {


### PR DESCRIPTION
USSO auth is problematic because it only works if you
have previously authenticated with USSO auth with the
identity manager and hence already have an account record there.

Since the main reason this was present was to enable non-interactive
authentication and we now support the agent authentication protocol,
disable USSO auth in favour of that.