### PR TITLE
cmd/charm-ingest: Add the basics of whitelist parsing

### DIFF
--- a/cmd/charm-ingest/whitelist.go
+++ b/cmd/charm-ingest/whitelist.go
@@ -1,0 +1,90 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the GPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/juju/charmstore-client/internal/ingest"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charmrepo.v4/csclient/params"
+)
+
+// parseError is the error returned when a whitelist cannot be parsed.
+type parseError struct {
+	Filename string
+	Line     int
+	Err      error
+}
+
+func (e *parseError) Error() string {
+	return fmt.Sprintf("%s:%d: %v", e.Filename, e.Line, e.Err)
+}
+
+// parseWhitelist parses a whitelist of charms and bundles read from r
+// and returns a slice containing all of them.
+//
+// One entity is defined per line, with the entity id first, followed
+// by all the channels that should be considered for the entity,
+// separated by white space.
+//
+// If the entity id has no specified revision, the most recent published
+// revision for the channels will be specified.
+func parseWhitelist(filename string, r io.Reader) ([]ingest.WhitelistEntity, error) {
+	var entities []ingest.WhitelistEntity
+	fileScanner := bufio.NewScanner(r)
+	lineNum := 0
+
+	for fileScanner.Scan() {
+		lineNum++
+
+		entity, err := parseLine(fileScanner.Text())
+		if err != nil {
+			return nil, &parseError{
+				Filename: filename,
+				Line:     lineNum,
+				Err:      err,
+			}
+		}
+
+		if entity.EntityId == "" {
+			// Empty line, ignore
+			continue
+		}
+		entities = append(entities, entity)
+	}
+
+	if err := fileScanner.Err(); err != nil {
+		return nil, errgo.Mask(err)
+	}
+
+	return entities, nil
+}
+
+// parseLine parses the given line into a WhitelistEntity. If the line is empty, it
+// returns the zero WhitelistEntity value.
+func parseLine(line string) (ingest.WhitelistEntity, error) {
+	var entity ingest.WhitelistEntity
+
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		// Empty line
+		return entity, nil
+	}
+
+	entity.EntityId = fields[0]
+	entity.Channels = make([]params.Channel, len(fields)-1)
+	for i, channelStr := range fields[1:] {
+		channel := params.Channel(channelStr)
+		if !params.ValidChannels[channel] {
+			return entity, fmt.Errorf("invalid channel %q for entity %q", channelStr, entity.EntityId)
+		}
+		entity.Channels[i] = channel
+	}
+
+	return entity, nil
+}

--- a/cmd/charm-ingest/whitelist_test.go
+++ b/cmd/charm-ingest/whitelist_test.go
@@ -1,0 +1,64 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the GPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/charmstore-client/internal/ingest"
+	"gopkg.in/juju/charmrepo.v4/csclient/params"
+)
+
+var whiteListTests = []struct {
+	testName    string
+	whitelist   string
+	expect      []ingest.WhitelistEntity
+	expectError string
+}{{
+	testName: "valid_whitelist",
+	whitelist: `
+wordpress stable
+elasticsearch-30 beta stable
+
+trusty/redis-0 unpublished
+mongodb
+`,
+	expect: []ingest.WhitelistEntity{{
+		EntityId: "wordpress",
+		Channels: []params.Channel{params.StableChannel},
+	}, {
+		EntityId: "elasticsearch-30",
+		Channels: []params.Channel{params.BetaChannel, params.StableChannel},
+	}, {
+		EntityId: "trusty/redis-0",
+		Channels: []params.Channel{params.UnpublishedChannel},
+	}, {
+		EntityId: "mongodb",
+		Channels: []params.Channel{},
+	}},
+},
+	{
+		testName:    "invalid_channel",
+		whitelist:   `wordpress badchannel`,
+		expectError: `invalid_channel:1: invalid channel "badchannel" for entity "wordpress"`,
+	},
+}
+
+func TestParseWhitelist(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range whiteListTests {
+		c.Run(test.testName, func(c *qt.C) {
+			input := strings.NewReader(test.whitelist)
+			got, err := parseWhitelist(test.testName, input)
+			if test.expectError == "" {
+				c.Assert(err, qt.Equals, nil)
+			} else {
+				c.Assert(err, qt.ErrorMatches, test.expectError)
+			}
+			c.Assert(got, qt.DeepEquals, test.expect)
+		})
+	}
+}


### PR DESCRIPTION
CLI tool which uses this to follow.

The following are valid whitelist formats (charm-id channel channel channel):

```
wordpress stable
elasticsearch-30 beta stable
trusty/redis-0 unpublished
mongodb
```