### PR TITLE
internal/ingest: expose public ingest API.

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/charmrepo.v4/csclient"
 	"gopkg.in/juju/charmrepo.v4/csclient/params"
 )
 
@@ -16,6 +17,18 @@ type ingestParams struct {
 	src       csClient
 	dest      csClient
 	whitelist []WhitelistEntity
+}
+
+// IngestParams holds information about the charmstores to use for ingestion and the entities to whitelist
+type IngestParams struct {
+	// Src holds the charmstore client to ingest from.
+	Src *csclient.Client
+
+	// Dest holds the charmstore client to ingest into.
+	Dest *csclient.Client
+
+	// Whitelist holds a slice of entities to ingest.
+	Whitelist []WhitelistEntity
 }
 
 var errNotFound = errgo.New("entity not found")
@@ -111,6 +124,16 @@ type IngestStats struct {
 	FailedEntityCount   int
 	ArchivesCopiedCount int
 	Errors              []string
+}
+
+// Ingest retrieves whitelisted entities from one charmstore and adds them to another,
+// returning statistics on this operation.
+func Ingest(params IngestParams) IngestStats {
+	return ingest(ingestParams{
+		src:       charmstoreShim{params.Src},
+		dest:      charmstoreShim{params.Dest},
+		whitelist: params.Whitelist,
+	})
 }
 
 func ingest(p ingestParams) IngestStats {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -17,20 +17,20 @@ func TestIngestWithRealCharmstore(t *testing.T) {
 			destStore := newTestCharmstore(c)
 			destStore.addEntities(c, test.dest)
 
-			stats := ingest(ingestParams{
-				src:       charmstoreShim{srcStore.client},
-				dest:      charmstoreShim{destStore.client},
-				whitelist: test.whitelist,
+			stats := Ingest(IngestParams{
+				Src:       srcStore.client,
+				Dest:      destStore.client,
+				Whitelist: test.whitelist,
 			})
 			c.Check(stats, qt.DeepEquals, test.expectStats)
 			destStore.assertContents(c, test.expectContents)
 
 			// Try again; we should transfer nothing and the contents should
 			// remain the same.
-			stats = ingest(ingestParams{
-				src:       charmstoreShim{srcStore.client},
-				dest:      charmstoreShim{destStore.client},
-				whitelist: test.whitelist,
+			stats = Ingest(IngestParams{
+				Src:       srcStore.client,
+				Dest:      destStore.client,
+				Whitelist: test.whitelist,
 			})
 			expectStats := test.expectStats
 			expectStats.ArchivesCopiedCount = 0


### PR DESCRIPTION
Exposes a small public wrapper for internal/ingest.