### PR TITLE
List command returns a "not logged in message" when not logged in.

### DIFF
--- a/cmd/charm/charmcmd/list.go
+++ b/cmd/charm/charmcmd/list.go
@@ -74,6 +74,16 @@ func (c *listCommand) Run(ctxt *cmd.Context) error {
 	defer client.jar.Save()
 
 	if c.users == "" {
+		csurl := client.ServerURL()
+		storeurl, err := url.Parse(csurl)
+		if err != nil {
+			return errgo.Notef(err, "invalid URL %q for JUJU_CHARMSTORE", csurl)
+		}
+		storeurl.Path = strings.TrimSuffix(storeurl.Path, "/") + "/"
+		if len(client.jar.Cookies(storeurl)) == 0 {
+			fmt.Fprintf(ctxt.Stdout, "not logged into %v\n", csurl)
+			return nil
+		}
 		resp, err := client.WhoAmI()
 		if err != nil {
 			return errgo.Notef(err, "cannot retrieve identity")

--- a/cmd/charm/charmcmd/list_test.go
+++ b/cmd/charm/charmcmd/list_test.go
@@ -8,6 +8,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"gopkg.in/juju/charm.v6"
 
+	"github.com/juju/charmstore-client/cmd/charm/charmcmd"
 	"github.com/juju/charmstore-client/internal/entitytesting"
 )
 
@@ -24,12 +25,19 @@ func (s *listSuite) Init(c *qt.C) {
 	s.charmstoreEnv = initCharmstoreEnv(c)
 }
 
+func (s *listSuite) TestNotLoggedIn(c *qt.C) {
+	stdout, stderr, exitCode := run(c.Mkdir(), "list")
+	c.Assert(stderr, qt.Equals, "")
+	c.Assert(exitCode, qt.Equals, 0)
+	c.Assert(stdout, qt.Matches, "not logged into "+charmcmd.ServerURL()+"\n")
+}
+
 func (s *listSuite) TestInvalidServerURL(c *qt.C) {
 	c.Setenv("JUJU_CHARMSTORE", "#%zz")
 	stdout, stderr, exitCode := run(c.Mkdir(), "list")
 	c.Assert(stdout, qt.Equals, "")
 	c.Assert(exitCode, qt.Equals, 1)
-	c.Assert(stderr, qt.Equals, "ERROR cannot retrieve identity: parse #%zz/v5/whoami: invalid URL escape \"%zz\"\n")
+	c.Assert(stderr, qt.Equals, "ERROR invalid URL \"#%zz\" for JUJU_CHARMSTORE: parse #%zz: invalid URL escape \"%zz\"\n")
 }
 
 func (s *listSuite) TestListUserProvided(c *qt.C) {


### PR DESCRIPTION
This fixes #136

The charm list command now behaves the same way as the charm whoami command when you are not logged in:
```
$GOPATH/bin/charm list
not logged into https://api.jujucharms.com/charmstore
$GOPATH/bin/charm whoami
not logged into https://api.jujucharms.com/charmstore
```
It also checks whether the URL is valid and I have added an extra unit test to make sure I have coverage.