### PR TITLE
cmd/charm-ingest: use --hardlimit not --softlimit

### DIFF
--- a/cmd/charm-ingest/main.go
+++ b/cmd/charm-ingest/main.go
@@ -50,7 +50,7 @@ Currently there is no way to specify username/password for the source charmstore
 func main() {
 	debug := gnuflag.Bool("debug", false, "show debugging messages")
 	maxDisk := gnuflag.Int64("maxdisk", 0, "max disk space to use (0 means unlimited)")
-	softDiskLimit := gnuflag.Bool("softlimit", true, "allow any single resource to exceed disk limit")
+	hardDiskLimit := gnuflag.Bool("hardlimit", false, "do not transfer any resources larger than the disk limit")
 	var auth authInfo
 	gnuflag.Var(&auth, "auth", "user:passwd to use for basic HTTP authentication to destination URL")
 	gnuflag.Usage = func() {
@@ -91,7 +91,7 @@ func main() {
 		Dest:          newCharmStoreClient(destURL, bakeryClient, &auth),
 		Whitelist:     whitelist,
 		MaxDisk:       *maxDisk,
-		SoftDiskLimit: *softDiskLimit,
+		SoftDiskLimit: !*hardDiskLimit,
 	}
 	if *debug {
 		p.Log = func(s string) {


### PR DESCRIPTION
Boolean flags with true defaults are a pain, so switch the sense
of the flag.