### PR TITLE
Disallow release in promulgated namespace

### DIFF
--- a/cmd/charm/charmcmd/release.go
+++ b/cmd/charm/charmcmd/release.go
@@ -86,6 +86,9 @@ func (c *releaseCommand) Init(args []string) error {
 	if err != nil {
 		return errgo.Notef(err, "invalid charm or bundle id")
 	}
+	if id.User == "" {
+		return errgo.Newf("charm user needs to be specified")
+	}
 	if id.Revision == -1 {
 		return errgo.Newf("charm revision needs to be specified")
 	}

--- a/cmd/charm/charmcmd/release_test.go
+++ b/cmd/charm/charmcmd/release_test.go
@@ -43,6 +43,10 @@ var releaseInitErrorTests = []struct {
 	args:  []string{"invalid:entity"},
 	err:   `invalid charm or bundle id: cannot parse URL "invalid:entity": schema "invalid" not valid`,
 }, {
+	about: "no charm user",
+	args:  []string{"wordpress"},
+	err:   `charm user needs to be specified`,
+}, {
 	about: "too many args",
 	args:  []string{"wordpress", "foo"},
 	err:   "too many arguments",

--- a/cmd/charm/charmcmd/release_test.go
+++ b/cmd/charm/charmcmd/release_test.go
@@ -48,23 +48,23 @@ var releaseInitErrorTests = []struct {
 	err:   `charm user needs to be specified`,
 }, {
 	about: "too many args",
-	args:  []string{"wordpress", "foo"},
+	args:  []string{"~bob/wordpress", "foo"},
 	err:   "too many arguments",
 }, {
 	about: "no resource",
-	args:  []string{"wily/wordpress", "--resource"},
+	args:  []string{"~bob/wily/wordpress", "--resource"},
 	err:   "flag needs an argument: --resource",
 }, {
 	about: "no revision",
-	args:  []string{"wily/wordpress", "--resource", "foo"},
+	args:  []string{"~bob/wily/wordpress", "--resource", "foo"},
 	err:   `invalid value "foo" for flag --resource: expected name-revision format`,
 }, {
 	about: "no resource name",
-	args:  []string{"wily/wordpress", "--resource", "-3"},
+	args:  []string{"~bob/wily/wordpress", "--resource", "-3"},
 	err:   `invalid value "-3" for flag --resource: expected name-revision format`,
 }, {
 	about: "bad revision number",
-	args:  []string{"wily/wordpress", "--resource", "someresource-bad"},
+	args:  []string{"~bob/wily/wordpress", "--resource", "someresource-bad"},
 	err:   `invalid value "someresource-bad" for flag --resource: invalid revision number`,
 }}
 
@@ -83,7 +83,7 @@ func (s *releaseSuite) TestInitError(c *qt.C) {
 
 func (s *releaseSuite) TestRunNoSuchCharm(c *qt.C) {
 	s.discharger.SetDefaultUser("bob")
-	stdout, stderr, code := run(c.Mkdir(), "release", "no-such-entity-55", "--channel", "stable")
+	stdout, stderr, code := run(c.Mkdir(), "release", "~bob/no-such-entity-55", "--channel", "stable")
 	c.Assert(stdout, qt.Equals, "")
 	c.Assert(stderr, qt.Matches, "ERROR cannot release charm or bundle: no matching charm or bundle for cs:no-such-entity-55\n")
 	c.Assert(code, qt.Equals, 1)

--- a/cmd/charm/charmcmd/release_test.go
+++ b/cmd/charm/charmcmd/release_test.go
@@ -85,7 +85,7 @@ func (s *releaseSuite) TestRunNoSuchCharm(c *qt.C) {
 	s.discharger.SetDefaultUser("bob")
 	stdout, stderr, code := run(c.Mkdir(), "release", "~bob/no-such-entity-55", "--channel", "stable")
 	c.Assert(stdout, qt.Equals, "")
-	c.Assert(stderr, qt.Matches, "ERROR cannot release charm or bundle: no matching charm or bundle for cs:no-such-entity-55\n")
+	c.Assert(stderr, qt.Matches, "ERROR cannot release charm or bundle: no matching charm or bundle for cs:~bob/no-such-entity-55\n")
 	c.Assert(code, qt.Equals, 1)
 }
 


### PR DESCRIPTION
For promulgated charms, releasing new revisions must happen in the user namespace, rather than in the promulgated "namespace".  Doing otherwise can lead to broken channels and 404s in the store.