### PR TITLE
fix the build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ replace github.com/altoros/gosigma => github.com/juju/gosigma v0.0.0-20200420012
 replace gopkg.in/mgo.v2 => github.com/juju/mgo v0.0.0-20190418114320-e9d4866cb7fc
 
 replace github.com/hashicorp/raft => github.com/juju/raft v2.0.0-20200420012049-88ad3b3f0a54+incompatible
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6


### PR DESCRIPTION
Fix the build issue when I was trying to [keep the formula to the latest](https://github.com/Homebrew/homebrew-core/pull/64511) 

```
# github.com/docker/docker/pkg/term
/Users/rchen/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/docker/docker@v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/pkg/term/tc.go:13:28: undefined: unix.SYS_IOCTL
/Users/rchen/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/docker/docker@v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/pkg/term/tc.go:18:28: undefined: unix.SYS_IOCTL
/Users/rchen/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/docker/docker@v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/pkg/term/termios_bsd.go:24:31: undefined: unix.SYS_IOCTL
/Users/rchen/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/docker/docker@v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/pkg/term/termios_bsd.go:37:31: undefined: unix.SYS_IOCTL
```